### PR TITLE
Fix macOS build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -82,6 +82,7 @@ AC_CHECK_FUNCS([dup2])
 AC_CHECK_FUNCS([strerror])
 AC_CHECK_FUNCS([uname])
 AC_CHECK_FUNCS([vfork])
+AC_CHECK_FUNCS([execvpe])
 AC_FUNC_FORK
 
 AC_CONFIG_FILES([

--- a/lib/pkgxx/Makefile.am
+++ b/lib/pkgxx/Makefile.am
@@ -30,7 +30,7 @@ libpkgxx_la_SOURCES = \
 libpkgxx_la_CXXFLAGS = \
 	-I$(top_builddir)/lib \
 	-I$(top_srcdir)/lib \
-	-DCFG_PREFIX='"$(prefix)"'
+	-DCFG_PREFIX='"$(prefix)"' \
 	$(BZIP2_CPPFLAGS) \
 	$(LIBFETCH_CPPFLAGS) \
 	$(ZLIB_CPPFLAGS)

--- a/lib/pkgxx/mutex_guard.hxx
+++ b/lib/pkgxx/mutex_guard.hxx
@@ -37,7 +37,7 @@ namespace pkgxx {
 
         private:
             guarded<T>* _cell;
-            std::lock_guard<typename guarded<T>::mutex_t> _lk;
+            std::lock_guard<std::mutex> _lk;
         };
 
         /** In-place construction of type T inside guarded<T>.

--- a/lib/pkgxx/nursery.hxx
+++ b/lib/pkgxx/nursery.hxx
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cassert>
+#include <condition_variable>
 #include <deque>
 #include <exception>
 #include <functional>

--- a/lib/pkgxx/string_algo.hxx
+++ b/lib/pkgxx/string_algo.hxx
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <iterator>
 #include <optional>
+#include <string_view>
 
 #include <pkgxx/ordered.hxx>
 

--- a/lib/pkgxx/xargs_fold.hxx
+++ b/lib/pkgxx/xargs_fold.hxx
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <exception>
 #include <cassert>
+#include <condition_variable>
 #include <deque>
 #include <istream>
 #include <memory>


### PR DESCRIPTION
Hi @depressed-pho!

I read your announcement of this tool and wanted to try it out on macOS (which uses clang). Unfortunately, there are a couple of fixes needed.

Note that I am not sure if the fix in `mutex_guard.hxx` is what you intended. However, without it, clang can't seem to find the `mutex_t` type:

```
In file included from check.cxx:5:
../../lib/pkgxx/mutex_guard.hxx:40:50: error: no type named 'mutex_t' in 'guarded<T>'
            std::lock_guard<typename guarded<T>::mutex_t> _lk;
                            ~~~~~~~~~~~~~~~~~~~~~^~~~~~~
```

There are a few more warnings that look like mistakes, but they did not break compilation, so I did not investigate deeper :) I also did not try the resulting binary yet.

Anyway, thank you for working on this, I think this is an exciting project! And I haven't done any C++ lately, so hacking on this was a welcome change of pace for me :)