### PR TITLE
Fix a bunch of compile warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,7 +44,7 @@ AX_APPEND_COMPILE_FLAGS([ dnl
     -Werror=return-type dnl
     -Wnull-dereference dnl
     -Wuninitialized dnl
-])
+], [], [-Werror])
 AC_LANG_POP([C++])
 
 # Checks for programs.

--- a/lib/pkgxx/environment.cxx
+++ b/lib/pkgxx/environment.cxx
@@ -45,7 +45,7 @@ namespace pkgxx {
                         CFG_PREFIX "/etc/mk.conf",
                         "/etc/mk.conf"
                     };
-                    for (auto const mkconf: candidates) {
+                    for (auto const &mkconf: candidates) {
                         if (fs::exists(mkconf)) {
                             vMAKECONF = mkconf;
                             break;
@@ -93,7 +93,7 @@ namespace pkgxx {
                         "../..",
                         "/usr/pkgsrc"
                     };
-                    for (auto const pkgsrcdir: candidates) {
+                    for (auto const &pkgsrcdir: candidates) {
                         if (fs::exists(pkgsrcdir / "mk/bsd.pkg.mk")) {
                             vPKGSRCDIR = fs::absolute(pkgsrcdir);
                             break;

--- a/lib/pkgxx/nursery.hxx
+++ b/lib/pkgxx/nursery.hxx
@@ -105,7 +105,7 @@ namespace pkgxx {
                 , _thr(std::bind(&worker::thread_main, this)) {}
             worker() = delete;
             worker(worker const&) = delete;
-            worker(worker&&) = default;
+            worker(worker&&) = delete;
 
             std::thread::id
             get_id() const {

--- a/src/pkg_chk/options.cxx
+++ b/src/pkg_chk/options.cxx
@@ -129,7 +129,9 @@ namespace pkg_chk {
             case '?':
                 throw bad_options();
             default:
-                throw std::logic_error("Unhandled option: " + static_cast<char>(ch));
+		std::string msg = "Unhandled option: ";
+		msg += static_cast<char>(ch);
+                throw std::logic_error(msg);
             }
         }
 

--- a/src/pkg_rr/options.cxx
+++ b/src/pkg_rr/options.cxx
@@ -102,7 +102,9 @@ namespace pkg_rr {
             case '?':
                 throw bad_options();
             default:
-                throw std::logic_error("Unhandled option: " + static_cast<char>(ch));
+		std::string msg = "Unhandled option: ";
+		msg += static_cast<char>(ch);
+                throw std::logic_error(msg);
             }
         }
     }


### PR DESCRIPTION
This PR fixes a number of warnings during the build with `clang` on macOS.

- Skip unknown compiler warning options
- Avoid per-iteration copies in some loops
- Delete a move constructor for a type containing a mutex
- Build up an exception string correctly

None of these changes are essential or high-priority but I hope you find them useful.