### PR TITLE
Fix compilation on Linux (Fedora 40)

### DIFF
--- a/lib/pkgxx/harness.cxx
+++ b/lib/pkgxx/harness.cxx
@@ -1,5 +1,6 @@
 #include <cassert>
 #include <cerrno>
+#include <cstring>
 #include <iostream>
 #include <sys/wait.h>
 #include <system_error>


### PR DESCRIPTION
I had this error compiling pkgchkxx on Fedora 40:

```
/bin/sh ../../libtool  --tag=CXX   --mode=compile g++ -std=c++17 -DHAVE_CONFIG_H -I.    -I../../lib -I../../lib -DCFG_PREFIX='"/usr/local"' -I/usr/pkg/include -I/usr/pkg/include -I/usr/pkg/include -g -O2 -Wall -Wextra -Wconversion -Wsuggest-attribute=cold -Wsuggest-attribute=format -Wsuggest-attribute=noreturn -Wsuggest-attribute=pure -Wsuggest-override -Werror=return-type -Wnull-dereference -Wuninitialized -Wno-pragmas -pthread -MT libpkgxx_la-harness.lo -MD -MP -MF .deps/libpkgxx_la-harness.Tpo -c -o libpkgxx_la-harness.lo `test -f 'harness.cxx' || echo './'`harness.cxx
libtool: compile:  g++ -std=c++17 -DHAVE_CONFIG_H -I. -I../../lib -I../../lib -DCFG_PREFIX=\"/usr/local\" -I/usr/pkg/include -I/usr/pkg/include -I/usr/pkg/include -g -O2 -Wall -Wextra -Wconversion -Wsuggest-attribute=cold -Wsuggest-attribute=format -Wsuggest-attribute=noreturn -Wsuggest-attribute=pure -Wsuggest-override -Werror=return-type -Wnull-dereference -Wuninitialized -Wno-pragmas -pthread -MT libpkgxx_la-harness.lo -MD -MP -MF .deps/libpkgxx_la-harness.Tpo -c harness.cxx  -fPIC -DPIC -o .libs/libpkgxx_la-harness.o
harness.cxx: In member function 'virtual const char* pkgxx::process_died_of_signal::what() const':
harness.cxx:308:19: error: 'strsignal' was not declared in this scope; did you mean 'ssignal'?
  308 |                << strsignal(st.signal)
      |                   ^~~~~~~~~
      |                   ssignal
```

`strsignal` is declared in `string.h` but not in `<string>` for some reason. This adds a `<cstring>` include to fix that.